### PR TITLE
Add Dockerfile for koek app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
 version: '3.9'
 
 services:
+  koopovereenkomst-app:
+    build:
+      context: koopovereenkomst-v3-simple
+    ports:
+      - 3000:3000
+
   solid-pod-provider:
     build:
       context: community-server
     command: -p 3001
     environment:
-        - CSS_ROOT_FILE_PATH=/data
+      - CSS_ROOT_FILE_PATH=/data
     ports:
-        - 3001:3001
+      - 3001:3001
     volumes:
-        - ./solid-pod-provider/data:/data
+      - ./solid-pod-provider/data:/data

--- a/koopovereenkomst-v3-simple/Dockerfile
+++ b/koopovereenkomst-v3-simple/Dockerfile
@@ -1,0 +1,58 @@
+# Copied from: https://github.com/vercel/next.js/tree/canary/examples/with-docker
+# Install dependencies only when needed
+FROM node:16-alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+
+# Rebuild the source code only when needed
+FROM node:16-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN yarn build
+
+# If using npm comment out above and use below instead
+# RUN npm run build
+
+# Production image, copy all the files and run next
+FROM node:16-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+
+CMD ["node", "server.js"]

--- a/koopovereenkomst-v3-simple/components/LoginForm.tsx
+++ b/koopovereenkomst-v3-simple/components/LoginForm.tsx
@@ -32,7 +32,6 @@ export default function LoginForm() {
                 <option value="https://solidcommunity.net">Solid Community</option>
                 <option value="https://broker.pod.inrupt.com">Inrupt</option>
                 <option value="http://localhost:3001">localhost:3001</option>
-                <option value="http://localhost:3002">localhost:3002</option>
             </select>
             <LoginButton
                 authOptions={{ clientName: siteTitle }}

--- a/koopovereenkomst-v3-simple/next.config.js
+++ b/koopovereenkomst-v3-simple/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
   images: {
     loader: "custom",
   },
+  output: 'standalone',
   async redirects() {
     return [
       {


### PR DESCRIPTION
`docker compose` had nu alleen nog de pod provider. Koopovereenkomst app daaraan toegevoegd, zodat de hele stack getest/bekeken/gedemo'd kan worden met enkel Docker