### PR TITLE
feat: add RDF checker to CI

### DIFF
--- a/.github/workflows/ci-rdf.yml
+++ b/.github/workflows/ci-rdf.yml
@@ -1,0 +1,10 @@
+name: RDF data validation
+
+on: push
+
+jobs:
+  rdf-syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: RDF syntax check
+        uses: AtomGraph/RDF-syntax-check@v1.0.4

--- a/solid-pod-provider/data/koopovereenkomst-123.ttl
+++ b/solid-pod-provider/data/koopovereenkomst-123.ttl
@@ -11,7 +11,7 @@
 
 koopovereenkomst:123
     a zvg:Koop;
-    zvg:aangebodenDoor marc:;
+    zvg:aangebodenDoor
     zvg:aan janneke:;
     zvg:koopsom 412000;
     zvg:vanZakelijkRecht <https://data.kkg.kadaster.nl/id/zakelijkrecht/1004387823748930> .

--- a/solid-pod-provider/data/koopovereenkomst-123.ttl
+++ b/solid-pod-provider/data/koopovereenkomst-123.ttl
@@ -11,7 +11,7 @@
 
 koopovereenkomst:123
     a zvg:Koop;
-    zvg:aangebodenDoor
+    zvg:aangebodenDoor marc:;
     zvg:aan janneke:;
     zvg:koopsom 412000;
     zvg:vanZakelijkRecht <https://data.kkg.kadaster.nl/id/zakelijkrecht/1004387823748930> .


### PR DESCRIPTION
Came across the new GH Action https://github.com/AtomGraph/RDF-syntax-check and thought it would be a nice addition as we work with linked data extensively.

Edited koek ttl to be faulty to show a failing pipeline. PR can be squashed to clean up those test commits 😉