### PR TITLE
Show VC verification status

### DIFF
--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
@@ -6,8 +6,6 @@ import { Box } from "@mui/system";
 import VC, { SolidVC, VCType } from '../../src/VC';
 import Image from "../../src/Image";
 import { useCallback, useState } from "react";
-import { verifyVC } from "../../src/verify";
-import PodIcon from "../../src/PodIcon";
 
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -85,7 +83,7 @@ export default function Step2({ step = 2, handleNext, handleBack = () => { } }) 
       :
       <Box>
         <Typography variant="body1" color="text.primary" align="center">
-          Je hebt je persoonsgegevens opgeslagen in je datakluis. Kloppen de gegevens? <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={loadedBRPVC.url} />
+          Je hebt je persoonsgegevens opgeslagen in je datakluis. Kloppen de gegevens?
         </Typography>
         {/* https://mui.com/material-ui/react-table/ */}
         <TableContainer sx={{ marginY: '3rem' }} component={Paper}>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
@@ -6,13 +6,45 @@ import { Box } from "@mui/system";
 import VC, { VCType } from '../../src/VC';
 import Image from "../../src/Image";
 import { useState } from "react";
+import { verifyVC } from "../../src/verify";
+import PodIcon from "../../src/PodIcon";
+
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+
+function createData(
+  name: string,
+  value: string,
+) {
+  return { name, value };
+}
 
 export default function Step2({ step = 2, handleNext, handleBack = () => { } }) {
-  const [vcLoaded, setvcLoaded] = useState(false);
+  const [loadedBRPVC, setLoadedBRPVC] = useState({} as object);
+  const [loadedBRPVCUrl, setLoadedBRPVCUrl] = useState("" as string);
+  const [loadedBRPVCVerification, setLoadedBRPVCVerification] = useState({} as object);
 
-  const handleVC = (_vc) => {
+  const [rows, setRows] = useState([] as Array<any>);
+
+  const handleVC = async (vc: any, url: string) => {
     // get a trigger from <VC> to enable the "Doorgaan" button
-    setvcLoaded(true);
+    const verificationResult = await verifyVC(vc);
+
+    setLoadedBRPVC(vc);
+    setLoadedBRPVCUrl(url);
+    setLoadedBRPVCVerification(verificationResult);
+
+    setRows([
+      createData('Naam', vc.credentialSubject.naam),
+      createData('Geboortedatum', vc.credentialSubject.geboorte.geboortedatum),
+      createData('Geboorteplaats', vc.credentialSubject.geboorte.geboorteplaats),
+      createData('Geboorteland', vc.credentialSubject.geboorte.geboorteland),
+      createData('Certificaat geldig?', verificationResult.verified ? '✅' : '❌'),
+    ]);
   };
 
   return (
@@ -24,21 +56,52 @@ export default function Step2({ step = 2, handleNext, handleBack = () => { } }) 
         {step}. Koppel je persoonsgegevens aan deze koopovereenkomst
       </Typography>
 
-      <Image
-        src="/solid-quest/images/mijnoverheid.png"
-        alt="Mijn Overheid Logo"
-        width={400}
-        height={180}
-        style={{ display: "block", margin: "25px auto" }}
-      />
+      {Object.keys(loadedBRPVC).length === 0 ?
+      <Box>
+        <Image
+          src="/solid-quest/images/mijnoverheid.png"
+          alt="Mijn Overheid Logo"
+          width={400}
+          height={180}
+          style={{ display: "block", margin: "25px auto" }}
+        />
 
-      <hr/>
-
-      <VC type={VCType.BRP} handleVC={handleVC}/>
+        <hr/>
+        <VC type={VCType.BRP} handleVC={handleVC}/>
+      </Box>
+      :
+      <Box>
+        <Typography variant="body1" color="text.primary" align="center">
+          Je hebt je persoonsgegevens opgeslagen in je datakluis. <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={loadedBRPVCUrl} />
+          <br/>Kloppen de gegevens?
+        </Typography>
+        {/* https://mui.com/material-ui/react-table/ */}
+        <TableContainer sx={{ marginY: '4rem' }} component={Paper}>
+          <Table sx={{ minWidth: 650 }} aria-label="simple table">
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
+                  key={row.name}
+                  sx={{ '&:last-child td, &:last-child th': {
+                    border: 0,
+                    fontStyle: 'italic',
+                    fontWeight: 'bold',
+                    height: '4rem',
+                  } }}
+                >
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell>{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+      }
 
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        {vcLoaded && <Button variant="contained" onClick={handleNext}>Doorgaan</Button> }
+        {Object.keys(loadedBRPVC).length !== 0 && <Button variant="contained" onClick={handleNext}>Doorgaan</Button> }
       </Stack>
     </Box>
   );

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
@@ -6,7 +6,6 @@ import { Box } from "@mui/system";
 import VC, { SolidVC, VCType } from '../../src/VC';
 import { useCallback, useState } from "react";
 
-import PodIcon from "../../src/PodIcon";
 import Image from "../../src/Image";
 import KadasterKnowledgeGraph from "../../src/KadasterKnowledgeGraph";
 
@@ -36,7 +35,7 @@ export default function Step3({ step = 3, handleNext, handleBack = () => { } }) 
       {loadedBRKVC.length !== 0 ?
         <Box>
           <Typography variant="body1" color="text.primary" align="center">
-            Je hebt je eigendomsgegevens opgeslagen in je datakluis. Kloppen de gegevens? <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={loadedBRKVC[0].url} />
+            Je hebt je eigendomsgegevens opgeslagen in je datakluis. Kloppen de gegevens?
           </Typography>
           <Typography variant="body1" color="text.primary" align="center" fontWeight="bold" fontStyle="italic">
             Certificaat geldig? {loadedBRKVC[0].status.verified ? "✅" : "❌"}

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
@@ -3,19 +3,19 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 import Button from "@mui/material/Button";
 import { Box } from "@mui/system";
-import VC, { VCType } from '../../src/VC';
-import { useState } from "react";
+import VC, { SolidVC, VCType } from '../../src/VC';
+import { useCallback, useState } from "react";
 
+import PodIcon from "../../src/PodIcon";
 import Image from "../../src/Image";
 import KadasterKnowledgeGraph from "../../src/KadasterKnowledgeGraph";
 
 export default function Step3({ step = 3, handleNext, handleBack = () => { } }) {
-  const [loadedBRKVC, setLoadedBRKVC] = useState({} as any);
+  const [loadedBRKVC, setLoadedBRKVC] = useState([] as any);
 
-  const handleVC = (vc) => {
-    // get a trigger from <VC> to enable the "Doorgaan" button
-    setLoadedBRKVC(vc);
-  };
+  const updateVCs = useCallback(async (vcs: SolidVC[]) => {
+    setLoadedBRKVC(vcs);
+  }, []);
 
   return (
     <Box sx={{flex: 1}}>
@@ -30,38 +30,42 @@ export default function Step3({ step = 3, handleNext, handleBack = () => { } }) 
         Bij het Kadaster kan je jouw eigendomsbewijzen ophalen, zodat je vervolgens de woning kunt selecteren die je wilt verkopen.
       </Typography>
 
-      <Image
-        src="/solid-quest/images/mijnkadaster.png"
-        alt="Mijn Overheid Logo"
-        width={400}
-        height={180}
-        style={{ display: "block", margin: "25px auto" }}
-      />
+      <VC type={VCType.BRK} updateVCs={updateVCs} />
 
       <hr />
-
-      <VC type={VCType.BRK} handleVC={handleVC} />
-
-      <hr />
-      {Object.keys(loadedBRKVC).length !== 0 ?
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-        >
-          <KadasterKnowledgeGraph objectId={(loadedBRKVC.credentialSubject.eigendom.perceel.identificatie as number)}/>
+      {loadedBRKVC.length !== 0 ?
+        <Box>
           <Typography variant="body1" color="text.primary" align="center">
+            Je hebt je eigendomsgegevens opgeslagen in je datakluis. Kloppen de gegevens? <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={loadedBRKVC[0].url} />
+          </Typography>
+          <Typography variant="body1" color="text.primary" align="center" fontWeight="bold" fontStyle="italic">
+            Certificaat geldig? {loadedBRKVC[0].status.verified ? "✅" : "❌"}
+          </Typography>
+          <Typography variant="body1" color="text.primary" align="center" sx={{
+            margin: "25px auto",
+            maxWidth: "600px",
+          }}>
             Het volgende object ID van het perceel is gevonden in de verifiable credential van het Kadaster.
             Maak gebruik van de Kadaster Knowledge Graph om informatie op te halen over je perceel.
           </Typography>
+          <KadasterKnowledgeGraph objectId={(loadedBRKVC[0].vc.credentialSubject.eigendom.perceel.identificatie as number)}/>
         </Box>
       :
+      <Box>
+        <Image
+          src="/solid-quest/images/mijnkadaster.png"
+          alt="Mijn Overheid Logo"
+          width={400}
+          height={180}
+          style={{ display: "block", margin: "25px auto" }}
+        />
         <KadasterKnowledgeGraph objectId={0}/>
+      </Box>
       }
 
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        {Object.keys(loadedBRKVC).length !== 0 && <Button variant="contained" onClick={handleNext}>Doorgaan</Button>}
+        {loadedBRKVC.length !== 0 && <Button variant="contained" onClick={handleNext}>Doorgaan</Button>}
       </Stack>
     </Box>
   );

--- a/koopovereenkomst-v3-simple/src/VC.tsx
+++ b/koopovereenkomst-v3-simple/src/VC.tsx
@@ -1,152 +1,235 @@
-import { fetch as solidFetch } from '@inrupt/solid-client-authn-browser';
+import { fetch as solidFetch } from "@inrupt/solid-client-authn-browser";
 import {
-    createContainerAt,
-    deleteFile,
-    deleteSolidDataset,
-    getContainedResourceUrlAll,
-    getFile,
-    getSolidDataset,
-    getSourceUrl,
-    saveFileInContainer,
-    overwriteFile,
-    WithResourceInfo,
-} from '@inrupt/solid-client';
+  createContainerAt,
+  deleteFile,
+  deleteSolidDataset,
+  getContainedResourceUrlAll,
+  getFile,
+  getSolidDataset,
+  getSourceUrl,
+  saveFileInContainer,
+  overwriteFile,
+  WithResourceInfo,
+} from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
-import Button from "@mui/material/Button";
-import { Box } from '@mui/material';
 
+import { useEffect, useCallback, useState } from "react";
+
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Box from "@mui/material/Box";
+import { Typography } from "@mui/material";
+import { verifyVC } from "./verify";
 
 export async function deleteRecursively(dataset) {
   console.log(dataset);
   const containedResourceUrls = getContainedResourceUrlAll(dataset);
-  const containedDatasets = await Promise.all(containedResourceUrls.map(async resourceUrl => {
-    try {
-      return await getSolidDataset(resourceUrl, { fetch: solidFetch });
-    } catch(e) {
-      // The Resource might not have been a SolidDataset;
-      // we can delete it directly:
-      await deleteFile(resourceUrl, { fetch: solidFetch });
-      return null;
-    }
-  }));
-  await Promise.all(containedDatasets.map(async containedDataset => {
-    if (containedDataset === null) {
-      return;
-    }
-    return await deleteRecursively(containedDataset);
-  }));
+  const containedDatasets = await Promise.all(
+    containedResourceUrls.map(async (resourceUrl) => {
+      try {
+        return await getSolidDataset(resourceUrl, { fetch: solidFetch });
+      } catch (e) {
+        // The Resource might not have been a SolidDataset;
+        // we can delete it directly:
+        await deleteFile(resourceUrl, { fetch: solidFetch });
+        return null;
+      }
+    })
+  );
+  await Promise.all(
+    containedDatasets.map(async (containedDataset) => {
+      if (containedDataset === null) {
+        return;
+      }
+      return await deleteRecursively(containedDataset);
+    })
+  );
   return await deleteSolidDataset(dataset, { fetch: solidFetch });
 }
 
 export enum VCType {
-  BRP = 'Basisregistratie Personen',
-  BRK = 'Basisregistratie Kadaster',
+  BRP = "Basisregistratie Personen",
+  BRK = "Basisregistratie Kadaster",
 }
 
-export default function VC({ type = VCType.BRP, handleVC = (vc, url?) => { } }) {
+const VCInfo = {
+  [VCType.BRP]: {
+    filename: "brp-credential.jsonld",
+    apiPath: "brp",
+  },
+  [VCType.BRK]: {
+    filename: "brk-credential.jsonld",
+    apiPath: "brk",
+  },
+};
 
-    const { session } = useSession();
-    const { webId } = session.info;
+export type SolidVC = {
+  url: string;
+  vc: any;
+  status: any;
+};
 
-    const SELECTED_POD = webId?.split('profile/card#me')[0];
-    const targetContainerURL = `${SELECTED_POD}credentials/`;
+export default function VC({ type = VCType.BRP, updateVCs = (vcs: SolidVC[]) => {} }) {
+  const { session } = useSession();
+  const { webId } = session.info;
 
-    const save_jsonld_file = async (filename: string, credential: any) => {
-      // Create Container to place VC in
+  const [vcs, setVcs] = useState([] as SolidVC[]);
+
+  const SELECTED_POD = webId?.split("profile/card#me")[0];
+  const targetContainerURL = `${SELECTED_POD}credentials/`;
+
+  const saveVCs = useCallback(async (vcs: any) => {
+      updateVCs(vcs);
+      setVcs(vcs);
+    },
+    [updateVCs]
+  );
+
+  const refreshVCsStatus = useCallback(async (vcs) => {
+    const updatedVcs = [];
+    for (let i = 0; i < vcs.length; i++) {
+      const { vc } = vcs[i];
+      const verificationResult = await verifyVC(vc);
+      console.log("refreshing status", verificationResult);
+      updatedVcs.push({ ...vcs[i], status: verificationResult });
+    }
+    saveVCs(updatedVcs);
+  }, [saveVCs]);
+
+  const listVCs = useCallback(async () => {
+    const vcs = [];
+    await getSolidDataset(targetContainerURL, { fetch: solidFetch })
+      .then((dataset) => {
+        const containedResourceUrls = getContainedResourceUrlAll(dataset);
+        containedResourceUrls.forEach((resourceUrl) => {
+          resourceUrl.endsWith(VCInfo[type].filename) && vcs.push(resourceUrl);
+        });
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+    return vcs;
+  }, [targetContainerURL, type]);
+
+  const loadVCs = useCallback(async (urls: string[]) => {
+      const vcs = [];
+      for (let i = 0; i < urls.length; i++) {
+        const file = await getFile(urls[i], { fetch: solidFetch });
+        const text = await file.text();
+        const credential = JSON.parse(text);
+        vcs.push({ url: urls[i], vc: credential, status: "❔" });
+      }
+      await saveVCs(vcs);
+      await refreshVCsStatus(vcs);
+    },
+    [saveVCs, refreshVCsStatus]
+  );
+
+  const initializeVCs = useCallback(async () => {
+    const vcUrls = await listVCs();
+    if (vcUrls.length > 0) {
       try {
-        const container = await getSolidDataset(targetContainerURL, { fetch: solidFetch });
-        // await deleteRecursively(container);
-        // await createContainerAt(targetContainerURL, { fetch: solidFetch });
+        await loadVCs(vcUrls);
       } catch (error) {
-        console.error(error);
-        await createContainerAt(targetContainerURL, { fetch: solidFetch });
-      }
-
-      // Upload file into the targetContainer.
-      console.log('json stringify credential', credential)
-      const blob = new Blob([JSON.stringify(credential, null, 2)], {type: "application/json;charset=utf-8"});
-
-      try {
-        let savedFile = await overwriteFile(
-          `${targetContainerURL}${filename}`,           // Container URL
-          blob,                         // File
-          { contentType: "application/ld+json", fetch: solidFetch }
-        );
-        console.log(`File saved at ${getSourceUrl(savedFile)}`);
-        return savedFile;
-      } catch (error) {
-        console.error(error);
-        return undefined;
+        console.log(error);
       }
     }
+  }, [listVCs, loadVCs]);
 
-    async function readSolidVC(file: Blob & WithResourceInfo) {
-      if (!file) {
-        return;
-      }
+  useEffect(() => {
+    // This function will run when the component mounts
+    initializeVCs();
+  }, [initializeVCs]);
 
-      const fileBlob = await getFile(getSourceUrl(file), { fetch: solidFetch });
-      const tekst = await fileBlob.text();
-      const content = JSON.parse(tekst);
-
-      return content;
+  const save_jsonld_file = async (filename: string, credential: any) => {
+    // Create Container to place VC in
+    try {
+      const container = await getSolidDataset(targetContainerURL, {
+        fetch: solidFetch,
+      });
+    } catch (error) {
+      await createContainerAt(targetContainerURL, { fetch: solidFetch });
     }
 
-    const vcAPI = async (service: string) => {
-        const response = await fetch(`http://localhost:8080/${service}/credentials/issue/${encodeURIComponent(webId)}`)
-        let result;
-        if (response.status >= 200 && response.status < 300) {
-            result = await response.json();
-        } else {
-            throw response;
-        }
+    // Upload file into the targetContainer.
+    console.log("json stringify credential", credential);
+    const blob = new Blob([JSON.stringify(credential, null, 2)], {
+      type: "application/json;charset=utf-8",
+    });
 
-        console.log("Recieved response", result);
-
-        return result.verifiableCredential;
+    try {
+      let savedFile = await overwriteFile(
+        `${targetContainerURL}${filename}`, // Container URL
+        blob, // File
+        { contentType: "application/ld+json", fetch: solidFetch }
+      );
+      console.log(`File saved at ${getSourceUrl(savedFile)}`);
+      return savedFile;
+    } catch (error) {
+      console.error(error);
+      return undefined;
     }
+  };
 
-    const vcAPIBRP = async () => {
-      const vc = await vcAPI('brp');
-      const savedFile = await save_jsonld_file('brp-credential.jsonld', vc);
-
-      console.log("Saved BRP credential");
-
-      handleVC(vc, savedFile.internal_resourceInfo.sourceIri);
-    }
-
-    const vcAPIBRK = async () => {
-      const vc = await vcAPI('brk');
-      const savedFile = await save_jsonld_file('brk-credential.jsonld', vc);
-
-      console.log("Saved BRK credential");
-
-      handleVC(vc, savedFile.internal_resourceInfo.sourceIri);
-    }
-
-    return (
-        <Box sx={{textAlign: "center"}}>
-            {type === VCType.BRP &&
-            <div>
-              <p>
-                Deze verifiable credential is op basis van de Basisregistratie Personen (BRP).
-              </p>
-              <p>
-                <Button variant="contained" color="secondary" onClick={vcAPIBRP}>Persoonsgegevens ophalen</Button>
-              </p>
-            </div>
-            }
-
-            {type === VCType.BRK &&
-            <div>
-              <p>
-                Deze verifiable credential is op basis van de Basisregistratie Kadaster (BRK).
-              </p>
-              <p>
-                <Button variant="contained" color="secondary" onClick={vcAPIBRK}>Eigendomsgegevens ophalen</Button>
-              </p>
-            </div>
-            }
-        </Box>
+  const vcAPI = async (service: string) => {
+    const response = await fetch(
+      `http://localhost:8080/${service}/credentials/issue/${encodeURIComponent(
+        webId
+      )}`
     );
+    let result;
+    if (response.status >= 200 && response.status < 300) {
+      result = await response.json();
+    } else {
+      throw response;
+    }
+
+    console.log("Recieved response", result);
+
+    return result.verifiableCredential;
+  };
+
+  const downloadVC = async () => {
+    const vc = await vcAPI(VCInfo[type].apiPath);
+    const savedFile = await save_jsonld_file(VCInfo[type].filename, vc);
+
+    console.log(`File saved for ${VCInfo[type]} at ${getSourceUrl(savedFile)}`);
+
+    await initializeVCs();
+  };
+  
+  const refreshVCs = async () => {
+    await initializeVCs();
+  };
+
+  const deleteVCs = async () => {
+    for (let i = 0; i < vcs.length; i++) {
+      const { url } = vcs[i];
+      console.log("delete", url);
+      await deleteFile(url, { fetch: solidFetch });
+    }
+    saveVCs([]);
+  };
+
+  return (
+    <Box sx={{ textAlign: "center", marginTop: "2rem" }}>
+      <Typography variant="h6" component="h1" gutterBottom>
+        Verifiable Credential(s) voor {type}
+      </Typography>
+      {vcs.length == 0 ? (
+        <Button color="secondary" onClick={downloadVC}>
+          VC Downloaden
+        </Button>
+      ) : (
+        <ButtonGroup variant="text" aria-label="text button group">
+          <Button color="secondary" onClick={refreshVCs}>
+            Status verversen
+          </Button>
+          <Button color="secondary" onClick={deleteVCs}>
+            VC Verwijderen
+          </Button>
+        </ButtonGroup>
+      )}
+    </Box>
+  );
 }

--- a/koopovereenkomst-v3-simple/src/VC.tsx
+++ b/koopovereenkomst-v3-simple/src/VC.tsx
@@ -18,7 +18,7 @@ import { useEffect, useCallback, useState } from "react";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Box from "@mui/material/Box";
-import { Typography } from "@mui/material";
+import { Link, Typography } from "@mui/material";
 import { verifyVC } from "./verify";
 
 export async function deleteRecursively(dataset) {
@@ -222,6 +222,11 @@ export default function VC({ type = VCType.BRP, updateVCs = (vcs: SolidVC[]) => 
         </Button>
       ) : (
         <ButtonGroup variant="text" aria-label="text button group">
+          <Link href={vcs[0].url} target="_blank">
+              <Button color="secondary">
+              VC Bekijken
+            </Button>
+          </Link>
           <Button color="secondary" onClick={refreshVCs}>
             Status verversen
           </Button>

--- a/koopovereenkomst-v3-simple/src/VC.tsx
+++ b/koopovereenkomst-v3-simple/src/VC.tsx
@@ -13,8 +13,6 @@ import {
 } from '@inrupt/solid-client';
 import { useSession } from "@inrupt/solid-ui-react";
 import Button from "@mui/material/Button";
-import PodIcon from "./PodIcon";
-import { useEffect, useState } from "react";
 import { Box } from '@mui/material';
 
 
@@ -45,12 +43,10 @@ export enum VCType {
   BRK = 'Basisregistratie Kadaster',
 }
 
-export default function VC({ type = VCType.BRP, handleVC = (vc) => { } }) {
+export default function VC({ type = VCType.BRP, handleVC = (vc, url?) => { } }) {
 
     const { session } = useSession();
     const { webId } = session.info;
-
-    const [VCUrl, setVCUrl] = useState("");
 
     const SELECTED_POD = webId?.split('profile/card#me')[0];
     const targetContainerURL = `${SELECTED_POD}credentials/`;
@@ -116,9 +112,7 @@ export default function VC({ type = VCType.BRP, handleVC = (vc) => { } }) {
 
       console.log("Saved BRP credential");
 
-      console.log(savedFile.internal_resourceInfo.sourceIri);
-      setVCUrl(savedFile.internal_resourceInfo.sourceIri);
-      handleVC(vc);
+      handleVC(vc, savedFile.internal_resourceInfo.sourceIri);
     }
 
     const vcAPIBRK = async () => {
@@ -127,8 +121,7 @@ export default function VC({ type = VCType.BRP, handleVC = (vc) => { } }) {
 
       console.log("Saved BRK credential");
 
-      setVCUrl(savedFile.internal_resourceInfo.sourceIri);
-      handleVC(vc);
+      handleVC(vc, savedFile.internal_resourceInfo.sourceIri);
     }
 
     return (
@@ -138,18 +131,9 @@ export default function VC({ type = VCType.BRP, handleVC = (vc) => { } }) {
               <p>
                 Deze verifiable credential is op basis van de Basisregistratie Personen (BRP).
               </p>
-              { !VCUrl &&
               <p>
                 <Button variant="contained" color="secondary" onClick={vcAPIBRP}>Persoonsgegevens ophalen</Button>
               </p>
-              }
-              {VCUrl &&
-              <p>
-                <span>✅ Opgeslagen! ➡</span>
-                <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={VCUrl} />
-                <em>👈 Tip: klik op het kluisje om de data in je kluis te bekijken!</em>
-              </p>
-              }
             </div>
             }
 
@@ -158,17 +142,9 @@ export default function VC({ type = VCType.BRP, handleVC = (vc) => { } }) {
               <p>
                 Deze verifiable credential is op basis van de Basisregistratie Kadaster (BRK).
               </p>
-              {!VCUrl &&
               <p>
                 <Button variant="contained" color="secondary" onClick={vcAPIBRK}>Eigendomsgegevens ophalen</Button>
               </p>
-              }
-              {VCUrl &&
-              <p>
-                <span>✅ Opgeslagen! ➡</span>
-                <PodIcon sx={{ mx: "1rem", verticalAlign: "middle" }} href={VCUrl} />
-              </p>
-              }
             </div>
             }
         </Box>

--- a/koopovereenkomst-v3-simple/src/verify.ts
+++ b/koopovereenkomst-v3-simple/src/verify.ts
@@ -1,0 +1,15 @@
+
+export async function verifyVC(vc: object): Promise<any> {
+    const url = 'http://localhost:8081/credentials/verify';
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            "verifiableCredential": vc
+        }),
+    });
+    const json = await response.json();
+    return json
+}


### PR DESCRIPTION
VC Verificatie toegevoegd, hiervoor is het VC component aangepast
- Als er nog geen VC is, is er de knop: VC Ophalen
- Als er wel een VC is, laad deze dan vanuit de Pod, en toon 'm. Je hoeft nu ook niet meer elke keer 'm opnieuw te downloaden
- Als er wel een VC is, toon 3 knoppen: bekijken, status verversen en verwijderen
  - bekijken dient als vervanging voor de podicon. Nu hebben we op 1 plek alle acties rondom de VC
  - status verversen is handig om te zien dat het vinkje een kruisje wordt, wanneer je de vc hebt gewijzigd in je pod 
  - verwijderen om 'm weg te gooien en opnieuw te kunnen binnenhalen

Stappen 2 en 3 zijn hierop aangepast. Stap 2 heeft nu een tabel gekregen voor het tonen van de VC data

![image](https://user-images.githubusercontent.com/56066664/228206042-1c73ba56-cb35-4a26-8f99-0aabccb779f5.png)
![image](https://user-images.githubusercontent.com/56066664/228206156-5e88294f-b740-4361-b7bd-ffdf6fdb488b.png)
![image](https://user-images.githubusercontent.com/56066664/228206188-b39a2d73-aead-4967-a293-6300f60f96c6.png)
![image](https://user-images.githubusercontent.com/56066664/228206258-05de4177-49d5-4917-8b35-4c2f58121d43.png)
