### PR TITLE
Steps status

### DIFF
--- a/koopovereenkomst-v3-simple/pages/koper.tsx
+++ b/koopovereenkomst-v3-simple/pages/koper.tsx
@@ -1,3 +1,4 @@
+import { useSession } from "@inrupt/solid-ui-react";
 import Head from "next/head";
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -5,7 +6,6 @@ import Box from "@mui/material/Box";
 import Step from "@mui/material/Step";
 import StepLabel from "@mui/material/StepLabel";
 import Stepper from "@mui/material/Stepper";
-import Typography from "@mui/material/Typography";
 
 import { default as solidQuery } from "@solid/query-ldflex/lib/exports/rdflib";
 import Layout from "../src/Layout";
@@ -28,40 +28,70 @@ const steps = [
   "Tekenen",
 ];
 
+interface StepEvents {
+  step: number;
+  events: string[]
+}
+
+const eventsPerStep: StepEvents[] = [
+  { step: 1, events: ['koopovereenkomstGeinitieerd', 'eigendomRefToegevoegd', 'koopprijsToegevoegd', 'datumVanLeveringToegevoegd'] },
+  { step: 2, events: ['koperRefToegevoegd',] },
+  { step: 3, events: ['conceptKoopovereenkomstGetekend',] },
+  { step: 4, events: ['conceptKoopovereenkomstGetekend',] },
+];
+
 export default function Koper() {
-  let koekRepo = new KoekRepository();
   solidQuery.context.extend(SOLID_ZVG_CONTEXT);
 
+  let koekRepo = new KoekRepository();
+
+  const { session } = useSession();
+  let isLoggedIn = session.info.isLoggedIn;
+
   const [activeStep, setActiveStep] = useState(0);
-  const [skipped, setSkipped] = useState(new Set<number>());
 
   const [koek, setActiveKoek] = useState(null as KoekAggregate);
   const [isKoekCompleted, setKoekCompleted] = useState(false);
 
-  const isStepOptional = (step: number) => {
-    // return step === 1;
-    return false;
-  };
-
-  const isStepSkipped = (step: number) => {
-    return skipped.has(step);
-  };
-
   const handleNext = () => {
     if (isKoekCompleted) {
-      setActiveStep(4);
+      setActiveStep(6);
     }
     else {
-      let newSkipped = skipped;
-      if (isStepSkipped(activeStep)) {
-        newSkipped = new Set(newSkipped.values());
-        newSkipped.delete(activeStep);
-      }
-
-      setActiveStep((prevActiveStep) => prevActiveStep + 1);
-      setSkipped(newSkipped);
+      setActiveStep((prevActiveStep) => {
+        let nextActiveStep = prevActiveStep + 1;
+        while ((koek) && (isStepCompleted(nextActiveStep) && nextActiveStep < 6)) {
+          nextActiveStep = nextActiveStep + 1;
+        }
+        return nextActiveStep;
+      });
     }
   };
+
+  const isStepCompleted = (index) => {
+    if (!isLoggedIn) {
+      return false;
+    }
+    else {
+      let result: boolean = Boolean(koek);
+      let curStep = eventsPerStep.filter((se) => se.step === index);
+      if (curStep.length === 0) {
+        result = true;
+      }
+      else if (koek && index === 1 && curStep.length === 1) {
+        let curStepEvents = curStep[0].events;
+        let events = koek.getEvents().map((e) => e.type);
+        result = curStepEvents.every((t) => events.includes(t));
+      }
+      else if (koek && curStep.length === 1) {
+        let curStepEvents = curStep[0].events;
+        let events = koek.getEvents().filter((e) => e.actor === 'koper-koos').map((e) => e.type);
+        result = curStepEvents.every((t) => events.includes(t));
+      }
+      // console.log('[%s] step %s is completed: %s (events: %s)', koek?.id, index, result, eventsPerStep.filter((se) => se.step === index).map((s) => s.events));
+      return result;
+    }
+  }
 
   const handleBack = () => {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
@@ -111,18 +141,10 @@ export default function Koper() {
         <ActiveStep value={activeStep} />
         <Stepper sx={{ width: "100%", minHeight: "4rem" }} activeStep={activeStep}>
           {steps.map((label, index) => {
-            const stepProps: { completed?: boolean } = { completed: isKoekCompleted };
+            const stepProps: { completed?: boolean } = { completed: isStepCompleted(index) };
             const labelProps: {
               optional?: React.ReactNode;
             } = {};
-            if (isStepOptional(index)) {
-              labelProps.optional = (
-                <Typography variant="caption">Optional</Typography>
-              );
-            }
-            if (isStepSkipped(index)) {
-              stepProps.completed = false;
-            }
             return (
               <Step key={label} {...stepProps}>
                 <StepLabel {...labelProps}>{label}</StepLabel>

--- a/koopovereenkomst-v3-simple/src/koek/KoekCommandHandler.ts
+++ b/koopovereenkomst-v3-simple/src/koek/KoekCommandHandler.ts
@@ -143,7 +143,7 @@ export default class KoekCommandHandler {
     }
 
     public async koopprijsVastgesteld(koopprijs: number): Promise<boolean> {
-        if (this.isDifferentKoopprijs(koopprijs)) {
+        if (koopprijs > 0 && this.isDifferentKoopprijs(koopprijs)) {
             console.log('[%s] store koopprijs', this.aggregateId, koopprijs);
             let eventType = this.koek.data.koopprijs > 0 ? 'koopprijsGewijzigd' : 'koopprijsToegevoegd';
             let event = this.buildEvent(
@@ -226,11 +226,11 @@ export default class KoekCommandHandler {
     private getCurrentActorFromWebId(): string {
         let actor: string;
         try {
-            if (this.webId.includes("localhost")) { 
-                actor = this.webId.split("3001")[1].split("/")[1]; 
+            if (this.webId.includes("localhost")) {
+                actor = this.webId.split("3001")[1].split("/")[1];
             }
-            else if (this.webId.includes("solidcommunity.net")) { 
-                actor = this.webId.split(".solidcommunity.net")[1].split("//")[1]; 
+            else if (this.webId.includes("solidcommunity.net")) {
+                actor = this.webId.split(".solidcommunity.net")[1].split("//")[1];
             }
         } catch (error) {
             console.log(`error extracting POD path`, error);


### PR DESCRIPTION
Als stappen al eerder doorlopen zijn (dus events hebben geproduceerd), dan zouden deze later overgeslagen moeten worden als een koopovereenkomst opnieuw geopend wordt. Dat werkt nu + dat de 'completed' steps ook zo worden weergegeven, zowel in de verkoper als de koper flow.

(de code is niet echt mooi schoon ... en werkt voldoende. Het zou nóg mooier zijn als de checks nog preciezer en meer te koppelen zijn aan de actors ... maar voor de demonstrator is dit voldoende - vind ik 😇 )

![image](https://github.com/kadaster-labs/solid-quest/assets/2315396/ad94a7c2-ed37-4f10-9405-ec58c7d88d83)
