### PR TITLE
Polishing + 'herladen koek' (ipv navigeren)

### DIFF
--- a/koopovereenkomst-v3-simple/pages/koper.tsx
+++ b/koopovereenkomst-v3-simple/pages/koper.tsx
@@ -55,12 +55,12 @@ export default function KoperFlow() {
 
   const handleNext = () => {
     if (isKoekCompleted) {
-      setActiveStep(5);
+      setActiveStep(4);
     }
     else {
       setActiveStep((prevActiveStep) => {
         let nextActiveStep = prevActiveStep + 1;
-        while ((koek) && (isStepCompleted(nextActiveStep) && nextActiveStep < 6)) {
+        while ((koek) && (isStepCompleted(nextActiveStep) && nextActiveStep < eventsPerStep.length)) {
           nextActiveStep = nextActiveStep + 1;
         }
         return nextActiveStep;
@@ -101,7 +101,7 @@ export default function KoperFlow() {
     setActiveKoek(await koekRepo.load(id, getWebId()));
   }
 
-  const loadKoek = async () => {
+  const reloadKoek = async () => {
     await selectKoek(koek.id);
   }
 
@@ -127,10 +127,10 @@ export default function KoperFlow() {
       case 2:
         return <Step3 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} />;
       case 3:
-        return <Step4 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} loadKoek={loadKoek} />;
+        return <Step4 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} reloadKoek={reloadKoek} />;
       case 4:
       default:
-        return <Step5 stepNr={props.value + 1} finished={isKoekCompleted} handleNext={handleNext} handleBack={handleBack} navigateToMyKoeks={navigateToMyKoeks} koek={koek} />;
+        return <Step5 stepNr={props.value + 1} finished={isKoekCompleted} handleNext={handleNext} handleBack={handleBack} navigateToMyKoeks={navigateToMyKoeks} reloadKoek={reloadKoek} koek={koek} />;
     }
   }
 

--- a/koopovereenkomst-v3-simple/pages/koper.tsx
+++ b/koopovereenkomst-v3-simple/pages/koper.tsx
@@ -55,7 +55,7 @@ export default function KoperFlow() {
 
   const handleNext = () => {
     if (isKoekCompleted) {
-      setActiveStep(6);
+      setActiveStep(5);
     }
     else {
       setActiveStep((prevActiveStep) => {
@@ -101,6 +101,10 @@ export default function KoperFlow() {
     setActiveKoek(await koekRepo.load(id, getWebId()));
   }
 
+  const loadKoek = async () => {
+    await selectKoek(koek.id);
+  }
+
   const navigateToMyKoeks = useCallback(() => {
     setActiveStep(1);
   }, []);
@@ -123,7 +127,7 @@ export default function KoperFlow() {
       case 2:
         return <Step3 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} />;
       case 3:
-        return <Step4 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} navigateToMyKoeks={navigateToMyKoeks} />;
+        return <Step4 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} loadKoek={loadKoek} />;
       case 4:
       default:
         return <Step5 stepNr={props.value + 1} finished={isKoekCompleted} handleNext={handleNext} handleBack={handleBack} navigateToMyKoeks={navigateToMyKoeks} koek={koek} />;

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
@@ -14,11 +14,11 @@ interface Step4Props {
   stepNr: number;
   handleNext: () => void;
   handleBack: () => void;
-  navigateToMyKoeks: () => void;
+  loadKoek: () => void;
   koek: KoekAggregate;
 }
 
-export default function Step4({ stepNr = 4, handleNext, handleBack, navigateToMyKoeks, koek }: Step4Props) {
+export default function Step4({ stepNr = 4, handleNext, handleBack, loadKoek, koek }: Step4Props) {
 
   const [koekComplete, setKoekComplete] = useState<boolean>(false);
 
@@ -52,7 +52,7 @@ export default function Step4({ stepNr = 4, handleNext, handleBack, navigateToMy
 
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        <Button variant="contained" onClick={navigateToMyKoeks}>Deelnemen Koopovereenkomst</Button>
+        <Button variant="contained" sx={{ marginLeft: "1em" }} onClick={loadKoek}>Herladen koopovereenkomst</Button>
         <Button variant="contained" onClick={handleNext} disabled={!koekComplete}>Doorgaan</Button>
       </Stack>
     </Box>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
@@ -14,11 +14,11 @@ interface Step4Props {
   stepNr: number;
   handleNext: () => void;
   handleBack: () => void;
-  loadKoek: () => void;
+  reloadKoek: () => void;
   koek: KoekAggregate;
 }
 
-export default function Step4({ stepNr = 4, handleNext, handleBack, loadKoek, koek }: Step4Props) {
+export default function Step4({ stepNr = 4, handleNext, handleBack, reloadKoek, koek }: Step4Props) {
 
   const [koekComplete, setKoekComplete] = useState<boolean>(false);
 
@@ -52,7 +52,7 @@ export default function Step4({ stepNr = 4, handleNext, handleBack, loadKoek, ko
 
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        <Button variant="contained" sx={{ marginLeft: "1em" }} onClick={loadKoek}>Herladen koopovereenkomst</Button>
+        <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>
         <Button variant="contained" onClick={handleNext} disabled={!koekComplete}>Doorgaan</Button>
       </Stack>
     </Box>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
@@ -96,7 +96,7 @@ export default function Step5({ stepNr = 5, finished = false, handleNext, handle
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
         {finished && <Button variant="contained" onClick={() => setShowModal(true)}>Inschrijven Openbaar Register</Button>}
-        <Button variant="contained" onClick={navigateToMyKoeks}>Deelnemen Koopovereenkomst</Button>
+        <Button variant="contained" onClick={navigateToMyKoeks}>Terug naar begin</Button>
         {!isGetekendDoorKoper && <Button variant="contained" onClick={handleAkkoord}>Ondertekenen</Button>}
       </Stack>
     </Box>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
@@ -15,6 +15,7 @@ interface StepProps {
   handleNext: () => void;
   handleBack: () => void;
   navigateToMyKoeks: () => void;
+  reloadKoek: () => void;
   koek: KoekAggregate;
 }
 
@@ -30,7 +31,7 @@ const style = {
   p: 4,
 };
 
-export default function Step5({ stepNr = 5, finished = false, handleNext, handleBack = () => { }, navigateToMyKoeks, koek }: StepProps) {
+export default function Step5({ stepNr = 5, finished = false, handleNext, handleBack, navigateToMyKoeks, reloadKoek, koek }: StepProps) {
 
   const [showModel, setShowModal] = useState(false);
   const [isGetekendDoorKoper, setIsGetekendDoorKoper] = useState(finished);
@@ -96,6 +97,7 @@ export default function Step5({ stepNr = 5, finished = false, handleNext, handle
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
         {finished && <Button variant="contained" onClick={() => setShowModal(true)}>Inschrijven Openbaar Register</Button>}
+        {!finished && <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>}
         <Button variant="contained" onClick={navigateToMyKoeks}>Terug naar begin</Button>
         {!isGetekendDoorKoper && <Button variant="contained" onClick={handleAkkoord}>Ondertekenen</Button>}
       </Stack>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
@@ -11,7 +11,8 @@ import Link from "../../src/Link";
 import Events from "../../src/ui-components/Events";
 
 export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, koek }) {
-  const [loadedBRKVCs, setLoadedBRKVCs] = useState([] as any);
+  const [loadedBRKVCs, setLoadedBRKVCs] = useState([] as SolidVC[]);
+  const [vcValid, setVcValid] = useState(false);
 
   const updateVCs = useCallback(async (vcs: SolidVC[]) => {
     setLoadedBRKVCs(vcs);
@@ -27,6 +28,8 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
       throw new Error(`Toevoegen eigendom VC is niet gelukt! (check console voor errors)`);
     }
   }, [loadedBRKVCs, handleNext, koek]);
+
+  // TODO useEffect with check VC and setVcValid
 
   return (
     <Box sx={{ flex: 1 }}>
@@ -78,7 +81,7 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
       <Events koek={koek} />
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        {loadedBRKVCs.length !== 0 && <Button variant="contained" onClick={handleAkkoord}>Akkoord</Button>}
+        {loadedBRKVCs.length !== 0 && <Button variant="contained" onClick={handleAkkoord} disabled={!vcValid}>Akkoord</Button>}
       </Stack>
     </Box>
   );

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
@@ -18,7 +18,7 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
     setLoadedBRKVCs(vcs);
 
     let vc = vcs[0];
-    if (vc.status.verified) {
+    if (typeof vc.status !== "string" && vc.status.verified) {
       setVcValid(true);
     } else {
       setVcValid(false);

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Box } from "@mui/system";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import VC, { SolidVC, VCType } from "../../src/verifiable/VC";
 
 import Image from "../../src/Image";
@@ -16,6 +16,14 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
 
   const updateVCs = useCallback(async (vcs: SolidVC[]) => {
     setLoadedBRKVCs(vcs);
+
+    let vc = vcs[0];
+    if (vc.status.verified) {
+      setVcValid(true);
+    } else {
+      setVcValid(false);
+    }
+
   }, []);
 
   const handleAkkoord = useCallback(async () => {
@@ -29,7 +37,9 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
     }
   }, [loadedBRKVCs, handleNext, koek]);
 
-  // TODO useEffect with check VC and setVcValid
+  useEffect(() => {
+
+  }, [updateVCs]);
 
   return (
     <Box sx={{ flex: 1 }}>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
@@ -6,6 +6,7 @@ import { Box } from "@mui/system";
 
 import { List, ListItem } from "@mui/material";
 import { useEffect, useState } from "react";
+import Link from "../../src/Link";
 import KoekAggregate from '../../src/koek/KoekAggregate';
 import { koopprijsFormatter } from "../../src/koek/KoekState";
 import Events from "../../src/ui-components/Events";
@@ -37,7 +38,7 @@ export default function Step6({ stepNr = 6, handleNext, handleBack, reloadKoek, 
 
       <Box>
         {koek && <Box>
-          <Typography>Koopovereenkomst #{koek.id}</Typography>
+          <Typography>Koopovereenkomst <Link href={koek?.data.iri} color="text.primary" target="_blank">#{koek?.id}</Link></Typography>
           <List>
             <ListItem>Type: {koek.data.typeKoopovereenkomst}</ListItem>
             <ListItem>Perceelnr: {koek.data.kadastraalObject?.perceelNummer}</ListItem>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
@@ -14,17 +14,17 @@ interface Step6Props {
   stepNr: number;
   handleNext: () => void;
   handleBack: () => void;
-  navigateToMyKoeks: () => void;
+  reloadKoek: () => void;
   koek: KoekAggregate;
 }
 
-export default function Step6({ stepNr = 6, handleNext, handleBack, navigateToMyKoeks, koek }: Step6Props) {
+export default function Step6({ stepNr = 6, handleNext, handleBack, reloadKoek, koek }: Step6Props) {
 
   const [koekComplete, setKoekComplete] = useState<boolean>(false);
 
   useEffect(() => {
     setKoekComplete(koek.isComplete());
-  }, [koek]);
+  }, [koek, reloadKoek]);
 
   return (
     <Box sx={{ flex: 1 }}>
@@ -52,7 +52,7 @@ export default function Step6({ stepNr = 6, handleNext, handleBack, navigateToMy
 
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        <Button variant="contained" onClick={navigateToMyKoeks}>Mijn Koopovereenkomsten</Button>
+        <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>
         <Button variant="contained" onClick={handleNext} disabled={!koekComplete}>Doorgaan</Button>
       </Stack>
     </Box>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
@@ -61,7 +61,7 @@ export default function Step7({ stepNr = 7, finished = false, handleNext, handle
       <Events koek={koek} />
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
-        <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>
+        {isGetekendDoorVerkoper && <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>}
         <Button variant="contained" onClick={navigateToMyKoeks}>Mijn Koopovereenkomsten</Button>
         {!isGetekendDoorVerkoper && <Button variant="contained" onClick={handleAkkoord}>Ondertekenen</Button>}
       </Stack>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
@@ -14,10 +14,11 @@ interface StepProps {
   handleNext: () => void;
   handleBack: () => void;
   navigateToMyKoeks: () => void;
+  reloadKoek: () => void;
   koek: KoekAggregate;
 }
 
-export default function Step7({ stepNr = 7, finished = false, handleNext, handleBack, navigateToMyKoeks, koek }: StepProps) {
+export default function Step7({ stepNr = 7, finished = false, handleNext, handleBack, navigateToMyKoeks, reloadKoek, koek }: StepProps) {
 
   const [isGetekendDoorVerkoper, setIsGetekendDoorVerkoper] = useState(finished);
 
@@ -60,6 +61,7 @@ export default function Step7({ stepNr = 7, finished = false, handleNext, handle
       <Events koek={koek} />
       <Stack direction="row" justifyContent="space-between">
         <Button variant="contained" onClick={handleBack}>Terug</Button>
+        <Button variant="contained" onClick={reloadKoek}>Herladen koopovereenkomst</Button>
         <Button variant="contained" onClick={navigateToMyKoeks}>Mijn Koopovereenkomsten</Button>
         {!isGetekendDoorVerkoper && <Button variant="contained" onClick={handleAkkoord}>Ondertekenen</Button>}
       </Stack>

--- a/koopovereenkomst-v3-simple/pages/verkoper.tsx
+++ b/koopovereenkomst-v3-simple/pages/verkoper.tsx
@@ -68,7 +68,7 @@ export default function VerkoperFlow() {
     else {
       setActiveStep((prevActiveStep) => {
         let nextActiveStep = prevActiveStep + 1;
-        while ((koek) && (isStepCompleted(nextActiveStep) && nextActiveStep < 6)) {
+        while ((koek) && (isStepCompleted(nextActiveStep) && nextActiveStep < eventsPerStep.length)) {
           nextActiveStep = nextActiveStep + 1;
         }
         return nextActiveStep;

--- a/koopovereenkomst-v3-simple/pages/verkoper.tsx
+++ b/koopovereenkomst-v3-simple/pages/verkoper.tsx
@@ -89,6 +89,10 @@ export default function VerkoperFlow() {
     setActiveKoek(await koekRepo.load(id, getWebId()));
   }, [koekRepo, setKoekRepo, loadKoekRepo]);
 
+  const reloadKoek = useCallback(async () => {
+    await selectKoek(koek.id);
+  }, [selectKoek, koek]);
+
   const navigateToMyKoeks = useCallback(() => {
     setActiveStep(1);
   }, []);
@@ -126,10 +130,10 @@ export default function VerkoperFlow() {
       case 4:
         return <Step5 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} />;
       case 5:
-        return <Step6 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} navigateToMyKoeks={navigateToMyKoeks} />;
+        return <Step6 stepNr={props.value + 1} handleNext={handleNext} handleBack={handleBack} koek={koek} reloadKoek={reloadKoek} />;
       case 6:
       default:
-        return <Step7 stepNr={props.value + 1} finished={isKoekCompleted} handleNext={handleNext} handleBack={handleBack} koek={koek} navigateToMyKoeks={navigateToMyKoeks} />;
+        return <Step7 stepNr={props.value + 1} finished={isKoekCompleted} handleNext={handleNext} handleBack={handleBack} koek={koek} navigateToMyKoeks={navigateToMyKoeks} reloadKoek={reloadKoek} />;
     }
   }
 

--- a/solid-pod-provider/data/.gitignore
+++ b/solid-pod-provider/data/.gitignore
@@ -1,2 +1,5 @@
 .internal/idp
 credentials/
+# generated keys
+public/
+private/

--- a/solid-pod-provider/data/verkoper-vera/profile/card$.ttl
+++ b/solid-pod-provider/data/verkoper-vera/profile/card$.ttl
@@ -12,7 +12,7 @@ pro:card a foaf:PersonalProfileDocument;
 <#me> a foaf:Person;
     rdfs:label "Verkoper Vera";
     vcard:bday "2022-08-19"^^xsd:date;
-    vcard:fn "Vera Veranda";
+    vcard:fn "Vera V";
     vcard:hasAddress <#id1680106718588>;
     vcard:hasEmail <#id1680182536910>;
     solid:oidcIssuer <http://localhost:3001/>;

--- a/start-backing-services.sh
+++ b/start-backing-services.sh
@@ -29,4 +29,4 @@ fi
 
 echo "Starting backing services for development ..."
 echo
-$cli_command up solid-pod-provider mock-overheid-server vc-api $build_flag
+$cli_command up solid-pod-provider mock-overheid-server $build_flag


### PR DESCRIPTION
Some last polishing the code 😁 ... plus het navigeren om te herladen is niet zo mooi. Nu knoppen 'Herladen koopovereenkomst' toegevoegd op strategische pagina's (steps):

Koper:
![image](https://github.com/kadaster-labs/solid-quest/assets/2315396/67592a0a-4d8f-4fa7-8701-f07def11037d)

en 

Verkoper:
![image](https://github.com/kadaster-labs/solid-quest/assets/2315396/7020e633-4125-4a0c-83c5-9358958f52cf)
