### PR TITLE
Text tweaks for demo

### DIFF
--- a/koopovereenkomst-v3-simple/pages/index.tsx
+++ b/koopovereenkomst-v3-simple/pages/index.tsx
@@ -84,14 +84,12 @@ export default function Home() {
         }}>
           <Link href="/verkoper" sx={cardStyle}>
             <h2>Verkoper &rarr;</h2>
-            <p>
-              Verkoper
-            </p>
+            <p><em>Ik wil een woning verkopen</em></p>
           </Link>
 
           <Link href="/koper" sx={cardStyle}>
             <h2>Koper &rarr;</h2>
-            <p>Koper start pagina.</p>
+            <p><em>Ik wil een woning kopen</em></p>
           </Link>
         </Container>
       </Box>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step1.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step1.tsx
@@ -95,9 +95,6 @@ export default function Step1({ stepNr = 1, handleNext }) {
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Ik wil een huis kopen
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koppelen van je Personal Online Datastore (POD)
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step2.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step2.tsx
@@ -34,9 +34,6 @@ export default function Step2({ stepNr = 2, handleNext, handleBack, selectKoek, 
 
   return (
     <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column', width: '100%' }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Ik wil een huis kopen
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Deelnemen koopovereenkomst
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step3.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step3.tsx
@@ -88,9 +88,6 @@ export default function Step3({ stepNr = 3, handleNext, handleBack = () => { }, 
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Ik wil een huis kopen
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koppel je persoonsgegevens aan deze koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step4.tsx
@@ -28,9 +28,6 @@ export default function Step4({ stepNr = 4, handleNext, handleBack, navigateToMy
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Ik wil een huis kopen
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Concept koopovereenkomst
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
@@ -65,9 +65,17 @@ export default function Step5({ stepNr = 5, finished = false, handleNext, handle
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h2" color="text.primary" align="center">
-        {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
-      </Typography>
+      <div>
+        {finished ? (
+          <Typography variant="h2" color="text.primary" align="center">
+            Proficiat! Je hebt een huis gekocht!
+          </Typography>
+        ) : (
+          <Typography variant="h2" color="text.primary" align="center">
+            {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
+          </Typography>
+        )}
+      </div>
 
       <Modal
         open={showModel}

--- a/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_koper/Step5.tsx
@@ -65,9 +65,6 @@ export default function Step5({ stepNr = 5, finished = false, handleNext, handle
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Ik wil een huis kopen
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step1.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step1.tsx
@@ -114,9 +114,6 @@ export default function Step1({ stepNr = 1, handleNext, loadKoekRepo, setVerkope
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koppelen van je Personal Online Datastore (POD)
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step2.tsx
@@ -106,9 +106,6 @@ export default function Step2({ stepNr = 2, handleNext, handleBack, selectKoek, 
 
   return (
     <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column', width: '100%' }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Selecteren koopovereenkomst
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step3.tsx
@@ -111,9 +111,6 @@ export default function Step3({ stepNr = 3, handleNext, handleBack = () => { }, 
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koppel je persoonsgegevens aan deze koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step4.tsx
@@ -30,9 +30,6 @@ export default function Step4({ stepNr = 4, handleNext, handleBack = () => { }, 
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koppel de woning die je wilt verkopen
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step5.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step5.tsx
@@ -67,9 +67,6 @@ export default function Step5({ stepNr = 5, handleNext, handleBack = () => { }, 
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Koopdetails voor koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step6.tsx
@@ -28,9 +28,6 @@ export default function Step6({ stepNr = 6, handleNext, handleBack, navigateToMy
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Concept koopovereenkomst
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
@@ -50,9 +50,6 @@ export default function Step7({ stepNr = 7, finished = false, handleNext, handle
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h1" color="text.primary" align="center">
-        Start een nieuwe koopovereenkomst
-      </Typography>
       <Typography variant="h2" color="text.primary" align="center">
         {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
       </Typography>

--- a/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
+++ b/koopovereenkomst-v3-simple/pages/steps_verkoper/Step7.tsx
@@ -50,9 +50,17 @@ export default function Step7({ stepNr = 7, finished = false, handleNext, handle
 
   return (
     <Box sx={{ flex: 1 }}>
-      <Typography variant="h2" color="text.primary" align="center">
-        {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
-      </Typography>
+      <div>
+        {finished ? (
+          <Typography variant="h2" color="text.primary" align="center">
+            Gefeliciteerd! Het huis is verkocht!
+          </Typography>
+        ) : (
+          <Typography variant="h2" color="text.primary" align="center">
+            {stepNr}. Tekenen koopovereenkomst <Typography variant="body1">#{koek?.id}</Typography>
+          </Typography>
+        )}
+      </div>
 
       <Events koek={koek} />
       <Stack direction="row" justifyContent="space-between">

--- a/koopovereenkomst-v3-simple/src/theme.ts
+++ b/koopovereenkomst-v3-simple/src/theme.ts
@@ -35,7 +35,8 @@ export const theme = createTheme({
       fontSize: "3rem",
     },
     h2: {
-      fontSize: "2rem",
+      fontSize: "2.5rem",
+      marginBottom: "1rem",
     }
   },
   components: {

--- a/koopovereenkomst-v3-simple/src/ui-components/MinimalizationModal.tsx
+++ b/koopovereenkomst-v3-simple/src/ui-components/MinimalizationModal.tsx
@@ -25,20 +25,47 @@ export default function MinimalizationModal({ data, open, onClose }: Props) {
         <DialogTitle>Dataminimalisatie</DialogTitle>
         <DialogContent>
           <Typography gutterBottom>
-            Bij VCs kan dataminimalisatie worden toegepast door alleen noodzakelijke informatie op te nemen en
-            Zero-knowledge Proofs te gebruiken om eigenschappen te bewijzen zonder gevoelige gegevens te onthullen.
-            Zodoende wordt alleen de relevante informatie opgenomen in het VC en niet meer dan dat.
+            Bij VCs is het mogelijk om dataminimalisatie toe te passen. Hiermee hoeft niet alle persoonsinformatie
+            gedeeld te worden, maar slechts de relevante informatie. Zo kun je bewijzen dat jij het echt bent, zonder al
+            je paspoortgegevens te hoeven delen. Hiermee wordt de privacy van de betrokkenen beter gewaarborgd.
           </Typography>
+          <hr />
           <Grid container spacing={2}>
             <Grid item xs={6}>
-              <Typography variant="h6">Voor</Typography>
-              <Typography variant="body1" component="pre" sx={{ wordWrap: 'break-word', whiteSpace: 'pre-wrap' }}>
+              <Typography variant="h6">Vóór minimalisatie</Typography>
+              <Typography variant="body1">
+                ➡ Alleen zichtbaar voor jezelf
+              </Typography>
+              <Typography
+                variant="body1"
+                component="pre"
+                sx={{
+                  wordWrap: "break-word",
+                  whiteSpace: "pre-wrap",
+                  backgroundColor: "rgba(255, 255, 255, 0.2)",
+                  borderRadius: "10px",
+                  padding: "20px",
+                }}
+              >
                 {JSON.stringify(data.before, null, 2)}
               </Typography>
             </Grid>
             <Grid item xs={6}>
-              <Typography variant="h6">Na</Typography>
-              <Typography variant="body1" component="pre" sx={{ wordWrap: 'break-word', whiteSpace: 'pre-wrap' }}>
+              <Typography variant="h6">Na minimalisatie</Typography>
+              <Typography variant="body1">
+                ➡ Zichtbaar voor jezelf én de koper
+              </Typography>
+              <Typography
+                variant="body1"
+                component="pre"
+                sx={{
+                  wordWrap: "break-word",
+                  whiteSpace: "pre-wrap",
+                  backgroundColor: "rgba(255, 255, 255, 0.2)",
+                  borderRadius: "10px",
+                  padding: "20px",
+                }}
+              >
                 {JSON.stringify(data.after, null, 2)}
               </Typography>
             </Grid>


### PR DESCRIPTION
- "Start een nieuwe koopovereenkomst" en "Ik wil een huis kopen" H1 headers verwijderd. Die voegden eigenlijk niks toe en waren enkel schermvuller.
- Vriendelijkere tekst op de start buttons toegevoegd. Dat was nog inconsistent ("Verkoper" vs "Koper start pagina")
- "Gefeliciteerd!" ipv "Tekenen koopovereenkomst"  wanneer die al is ondertekend
- Dataminimalisatie teksten aangepast. De uitleg en de Voor/Na teksten zijn verduidelijkt. Ook is de inhoud voorzien van een lichte achtergrondkleur. Zie screenshot hieronder

![image](https://github.com/kadaster-labs/solid-quest/assets/56066664/0e17121f-06c6-4102-a853-b4b4aafcf3cf)

