### PR TITLE
docs: update docs for running demo

### DIFF
--- a/Demonstrator.md
+++ b/Demonstrator.md
@@ -27,7 +27,7 @@ Bovenstaande is in detail uitgewerkt in een [Sequence Diagram](https://raw.githu
 - **v2**: Een tweede versie ... dit GitHub niet eens gehaald heeft
 - [**v3**](koopovereenkomst-v3-simple/): Een Next.js versie :tada:
 
-## Development
+## Running the demo
 
 Clone this repo which includes the [Mock Overheid Server](https://github.com/kadaster-labs/solid-quest-mock-overheid-server) repo as [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
 
@@ -35,21 +35,47 @@ Clone this repo which includes the [Mock Overheid Server](https://github.com/kad
 git clone --recurse-submodules https://github.com/kadaster-labs/solid-quest.git
 ```
 
-To start a 'verkoper' and 'koper' POD based on [Community Solid Server](https://github.com/CommunitySolidServer/CommunitySolidServer) use `docker-compose`:
+To start the complete demonstrator, including 'verkoper' and 'koper' PODs based on [Community Solid Server](https://github.com/CommunitySolidServer/CommunitySolidServer), use `docker-compose`:
 
 ```bash
 docker compose up --build
 ```
 
+The following endpoints are now available:
+- The koopovereenkomst app is running at [localhost:3000](http://localhost:3000)
 - Verkoper POD: [localhost:3001/verkoper-vera/](http://localhost:3001/verkoper-vera/)
 - Koper POD: [localhost:3001/koper-koos/](http://localhost:3001/koper-koos/)
 
-Open the app at [localhost:3000](http://localhost:3000)
+### Example PODs
+You can log in using the sample accounts of Vera and Koos. These have already been set up for you to start using the demonstrator right away. These accounts are completely fictional.
 
-### Voorbeeldaccounts
-Er kan ingelogd worden met de voorbeeldaccounts van Vera en Koos. Deze zijn alvast klaargezet waarmee je direct aan de slag kunt. Deze accounts zijn volledig fictief.
-
-| Rol           | E-mail           | Wachtwoord |
+| Role          | E-mail for login | Password   |
 | ------------- | ---------------- | ---------- |
 | Verkoper Vera | `vera@world.com` | `123456`   |
 | Koper Koos    | `koos@world.com` | `123456`   |
+
+## Development
+
+To start the backend services, execute the following command:
+
+```
+start-backing-services.sh
+```
+
+These services consist of:
+- Solid Pod Provider, which is an instance of the previously mentioned Community Solid Server.
+- Mock Overheid Server, which is a mock government and cadaster providing Verifiable Credentials to logged-in users.
+
+To run the frontend app, navigate to the `koopovereenkomst-v3-simple/` folder using the command:
+
+```
+cd koopovereenkomst-v3-simple/
+```
+
+Finally, start the frontend app by running:
+
+```
+yarn dev
+```
+
+This will start the development server for the frontend application.

--- a/Demonstrator.md
+++ b/Demonstrator.md
@@ -2,8 +2,6 @@
 
 Deze repo bevat (een eerste opzet voor) de **Demonstrator Koopovereenkomst Solid App**. Deze is bedoeld om kennis op te doen van hoe Solid PODs werken en hoe deze te gebruiken. In deze demonstator wordt een vereenvoudigde koopovereenkomst gesloten tussen Verkoper Vera en Koper Koos. In een eerste iteratie hadden wij bedacht dat Makelaar Mike het proces faciliteert en de verantwoordelijkheid heeft om het proces te initiëren, info toe te voegen die telefonisch of mondeling tussen verkoper en koper tot stand komt. Al werkende zijn we gekomen tot het punt dat een Solid POD vooral alle eigen data zou moeten vasthouden ... en dus _niet_ in een externe POD. Aangezien Verkoper Vera haar huis verkoopt, is zij ook initiator en 'eigenaar' van de koopovereenkomst. De eerste en meeste data komt dan ook in haar POD terecht. Uiteraard zou de data van Koper Koos vooral in zijn POD terecht moeten komen en een links naar elkaars PODs behoort tot beider data.
 
-[Live Demo](https://kadaster-labs.github.io/solid-quest/)
-
 ## Architectuur
 
 ![SoftwareArchitectuur](images/Architectuurschets_v3.jpg)
@@ -31,7 +29,7 @@ Bovenstaande is in detail uitgewerkt in een [Sequence Diagram](https://raw.githu
 
 ## Development
 
-Clone this repo which includes the [Mock Overheid Server](https://github.com/kadaster-labs/solid-quest-mock-overheid-server) and [VC API](https://github.com/kadaster-labs/solid-quest-vc-api) repos as [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+Clone this repo which includes the [Mock Overheid Server](https://github.com/kadaster-labs/solid-quest-mock-overheid-server) repo as [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
 
 ```bash
 git clone --recurse-submodules https://github.com/kadaster-labs/solid-quest.git
@@ -40,17 +38,18 @@ git clone --recurse-submodules https://github.com/kadaster-labs/solid-quest.git
 To start a 'verkoper' and 'koper' POD based on [Community Solid Server](https://github.com/CommunitySolidServer/CommunitySolidServer) use `docker-compose`:
 
 ```bash
-docker compose up solid-pod-provider
+docker compose up --build
 ```
 
 - Verkoper POD: [localhost:3001/verkoper-vera/](http://localhost:3001/verkoper-vera/)
 - Koper POD: [localhost:3001/koper-koos/](http://localhost:3001/koper-koos/)
 
-To start the 'Koopovereenkomst App' switch to the `koopovereenkomst-v3-simple` folder and run `yarn dev`:
-
-```bash
-cd koopovereenkomst-v3-simple
-yarn dev
-```
-
 Open the app at [localhost:3000](http://localhost:3000)
+
+### Voorbeeldaccounts
+Er kan ingelogd worden met de voorbeeldaccounts van Vera en Koos. Deze zijn alvast klaargezet waarmee je direct aan de slag kunt. Deze accounts zijn volledig fictief.
+
+| Rol           | E-mail           | Wachtwoord |
+| ------------- | ---------------- | ---------- |
+| Verkoper Vera | `vera@world.com` | `123456`   |
+| Koper Koos    | `koos@world.com` | `123456`   |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Solid Quest
 
-[Live Demo](https://kadaster-labs.github.io/solid-quest/)
-
 De Nederlandse overheid heeft de [Werkagenda Waardengedreven Digitaliseren](https://www.digitaleoverheid.nl/kabinetsbeleid-digitalisering/werkagenda/) opgesteld. Eén van de programmalijnen luidt: "Iedereen heeft regie op het digitale leven." *Daarvoor is regelgeving en beleid nodig, rond wallets en andere basisvoorzieningen.* [Solid](https://solidproject.org/) is een specificatie die het mogelijk maakt om je data op een veilige manier, decentraal, op te slaan in PODs, Personal Online Datastores. Als Kadaster bereiden wij ons voor op deze ontwikkelingen. Het begrijpen van de technologie is hiervoor randvoorwaardelijk. Daarom bouwen wij aan een demonstrator, met als voorbeeldusecase het opstellen van een koopovereenkomst, om de (on)mogelijkheden van Solid PODs te onderzoeken en begrijpen.
 
 Het is een (emerging) technologie waar we nog geen of nauwelijks ervaring mee hebben en ook benieuwd zijn hoe deze zich verhoudt tot andere ontwikkelingen:


### PR DESCRIPTION
- add login credentials for koos and vera to documentation
- remove references to GitHub pages, as it no longer works. It now requires a node.js backend, which cannot be hosted on GH Pages